### PR TITLE
TruckNo visible with link

### DIFF
--- a/lib/widgets/trackScreenDetailsWidget.dart
+++ b/lib/widgets/trackScreenDetailsWidget.dart
@@ -415,7 +415,10 @@ class _TrackScreenDetailsState extends State<TrackScreenDetails> {
                     ]),
                     Column(children: [
                       DynamicLinkService(
-                          deviceId: widget.deviceId, truckId: widget.truckId),
+                        deviceId: widget.deviceId,
+                        truckId: widget.truckId,
+                        truckNo: widget.TruckNo,
+                      ),
                       SizedBox(
                         height: 8,
                       ),


### PR DESCRIPTION
TruckNo was not passed to the next screen causing the problem of not printing the truckNo in the shared link string.