### PR TITLE
TruckNo visible with shared link.

### DIFF
--- a/lib/controller/dynamicLink.dart
+++ b/lib/controller/dynamicLink.dart
@@ -9,8 +9,8 @@ class DynamicLinkService extends StatefulWidget {
   String? truckNo;
   DynamicLinkService({
     required this.deviceId,
-    this.truckId,
-    this.truckNo,
+    required this.truckId,
+    required this.truckNo,
   });
 
   @override

--- a/lib/widgets/trackScreenDetailsWidget.dart
+++ b/lib/widgets/trackScreenDetailsWidget.dart
@@ -415,7 +415,10 @@ class _TrackScreenDetailsState extends State<TrackScreenDetails> {
                     ]),
                     Column(children: [
                       DynamicLinkService(
-                          deviceId: widget.deviceId, truckId: widget.truckId),
+                        deviceId: widget.deviceId,
+                        truckId: widget.truckId,
+                        truckNo: widget.TruckNo,
+                      ),
                       SizedBox(
                         height: 8,
                       ),

--- a/lib/widgets/whatsappShare.dart
+++ b/lib/widgets/whatsappShare.dart
@@ -17,8 +17,8 @@ class WhatsappShare extends StatefulWidget {
   String? truckNo;
   WhatsappShare({
     required this.deviceId,
-    this.truckId,
-    this.truckNo,
+    required this.truckId,
+    required this.truckNo,
   });
   @override
   _WhatsappShareState createState() => _WhatsappShareState();


### PR DESCRIPTION
TruckNo was not passed to the next screen causing the problem of not printing the truckNo in the shared link string. The params made required to avoid such mistakes ahead.